### PR TITLE
Add frontend password-reset feature

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -24,6 +24,8 @@ import { ChangePasswordComponent } from './pages/account/change-password/change-
 import { RecipeEditPageComponent } from './pages/recipe/recipe-edit-page/recipe-edit-page.component';
 import { EditMealComponent } from './pages/menu/edit-meal/edit-meal.component';
 import { MenuDisplayViewComponent } from './pages/menu/menu-display-view/menu-display-view.component';
+import { ForgotPasswordComponent } from './pages/auth/forgot-password/forgot-password-page';
+import { ResetPasswordComponent } from './pages/auth/reset-password/reset-password-page';
 
 export const mainTitle: string = "MenuMaestro"
 
@@ -58,6 +60,8 @@ export const routes: Routes = [
   { path: 'login', component: LoginComponent, title: `${mainTitle} - Login` },
   { path: 'register', component: AccountRegistration, title: `${mainTitle} - Register` },
   { path: 'accounts/verification', component: VerifyEmailComponent, title: `${mainTitle} - Verify Email` },
+  { path: 'forgot-password', component: ForgotPasswordComponent, title: `${mainTitle} - Forgot Password` },
+  { path: 'reset-password', component: ResetPasswordComponent, title: `${mainTitle} - Reset Password` },
   {
     path: 'organizations',
     children: [

--- a/frontend/src/app/pages/auth/forgot-password/forgot-password-page.html
+++ b/frontend/src/app/pages/auth/forgot-password/forgot-password-page.html
@@ -1,0 +1,58 @@
+<page-layout>
+  <div class="flex justify-center flex-1" *ngIf="!isLoading">
+    <div>
+      <h1 class="text-3xl text-center mb-8">Reset Your Password</h1>
+
+      <div *ngIf="!success">
+        <p class="text-gray-600 mb-6 text-center">
+          Enter your username and we'll send you a link to reset your password.
+        </p>
+
+        <form class="w-full mt-8" #form="ngForm" (ngSubmit)="requestPasswordReset()" (keydown.enter)="requestPasswordReset()">
+          <div class="flex flex-col mb-4">
+            <input-field
+              name="username"
+              [label]="'Username'"
+              class="col-span-2"
+              [className]="'w-full col-span-2'"
+              [type]="InputType.text"
+              [(value)]="username"
+              [form]="form"
+            ></input-field>
+            <div class="h-5">
+              <div *ngIf="submitted && !username" class="text-xs text-red-600 mt-1">
+                <p>Username is required!</p>
+              </div>
+            </div>
+          </div>
+
+          <simple-button className="w-full py-3 mt-2 font-semibold text-white rounded-lg" (click)="requestPasswordReset()">
+            Send Reset Link
+          </simple-button>
+
+          <div class="flex justify-center mt-3">
+            <a class="text-sm mr-1" [routerLink]="['/login']">Remember your password?</a>
+            <a class="text-sm text-primary underline hover:text-primary-light" [routerLink]="['/login']">
+              Log In
+            </a>
+          </div>
+        </form>
+      </div>
+
+      <div *ngIf="success" class="text-center">
+        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+          <p class="font-bold">Check your email!</p>
+          <p class="text-sm mt-2">
+            If an account exists with this username, you will receive an email with instructions to reset your password.
+          </p>
+        </div>
+
+        <simple-button className="w-full py-3 mt-4 font-semibold text-white rounded-lg" [routerLink]="['/login']">
+          Return to Login
+        </simple-button>
+      </div>
+    </div>
+  </div>
+
+  <loading-spinner [isLoading]="isLoading"></loading-spinner>
+</page-layout>

--- a/frontend/src/app/pages/auth/forgot-password/forgot-password-page.ts
+++ b/frontend/src/app/pages/auth/forgot-password/forgot-password-page.ts
@@ -1,0 +1,87 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterModule } from '@angular/router';
+import { AccountsApiService } from '../../../../generated';
+import { PageLayoutComponent } from '../../../components/Layout/PageLayout';
+import { FormsModule } from '@angular/forms';
+import { SimpleButtonComponent } from '../../../components/Button/SimpleButton';
+import { InputFieldComponent, InputType } from '../../../components/Input/InputField';
+import { ErrorService } from '../../../globals/error.service';
+import { LoadingSpinnerComponent } from '../../../components/LoadingSpinner/LoadingSpinner';
+
+@Component({
+    selector: 'app-forgot-password',
+    imports: [
+        CommonModule,
+        PageLayoutComponent,
+        FormsModule,
+        SimpleButtonComponent,
+        InputFieldComponent,
+        RouterModule,
+        LoadingSpinnerComponent,
+    ],
+    templateUrl: './forgot-password-page.html'
+})
+export class ForgotPasswordComponent {
+  InputType = InputType;
+  username: string = '';
+
+  // After first submission attempt, form validation will start
+  submitted = false;
+  // Success flag
+  success = false;
+  // Error flag
+  error = false;
+  errorMessage = '';
+
+  isLoading = false;
+
+  constructor(
+    private accountsApiService: AccountsApiService,
+    private router: Router,
+    private errorService: ErrorService
+  ) {}
+
+  /**
+   * Form validation will start after the method is called, additionally a password reset request will be sent
+   */
+  requestPasswordReset() {
+    this.submitted = true;
+    this.error = false;
+    this.success = false;
+
+    // Check if username is non-empty
+    if (this.username && this.username.trim().length > 0) {
+      this.initiatePasswordReset(this.username);
+    } else {
+      console.error('Invalid input');
+    }
+  }
+
+  /**
+   * Send password reset request to the backend. Always shows success message for security reasons.
+   *
+   * @param username username for password reset
+   */
+  initiatePasswordReset(username: string) {
+    this.isLoading = true;
+    this.accountsApiService.resetPasswordInitiate(username).subscribe({
+      next: () => {
+        this.isLoading = false;
+        this.success = true;
+        this.error = false;
+      },
+      error: (error) => {
+        this.isLoading = false;
+        // Even on error, we show success message for security reasons
+        // (don't want to leak information about whether username exists)
+        this.success = true;
+        this.error = false;
+        console.error('Password reset request error:', error);
+        this.errorService.printErrorResponse(error);
+      },
+    });
+  }
+
+  ngOnInit() {}
+}

--- a/frontend/src/app/pages/auth/login/login-page.html
+++ b/frontend/src/app/pages/auth/login/login-page.html
@@ -43,6 +43,11 @@
           Log In
         </simple-button>
         <div class="flex justify-center mt-3">
+          <a class="text-sm text-primary underline hover:text-primary-light" [routerLink]="['/forgot-password']">
+            Forgot Password?
+          </a>
+        </div>
+        <div class="flex justify-center mt-3">
           <a class="text-sm mr-1" [routerLink]="['/register']">New here?</a
           ><a class="text-sm text-primary underline hover:text-primary-light" [routerLink]="['/register']">
             Create an Account.</a

--- a/frontend/src/app/pages/auth/reset-password/reset-password-page.html
+++ b/frontend/src/app/pages/auth/reset-password/reset-password-page.html
@@ -1,0 +1,118 @@
+<page-layout>
+  <div class="flex justify-center flex-1" *ngIf="!isLoading">
+    <div>
+      <h1 class="text-3xl text-center mb-8">Set New Password</h1>
+
+      <div *ngIf="!success && !error">
+        <p class="text-gray-600 mb-6 text-center">
+          Enter your username and choose a new password for your account.
+        </p>
+
+        <form class="w-full mt-8" #form="ngForm" (ngSubmit)="resetPassword()" (keydown.enter)="resetPassword()">
+          <div class="flex flex-col mb-4">
+            <input-field
+              name="username"
+              [label]="'Username'"
+              class="col-span-2"
+              [className]="'w-full col-span-2'"
+              [type]="InputType.text"
+              [(value)]="username"
+              [form]="form"
+            ></input-field>
+            <div class="h-5">
+              <div *ngIf="submitted && !username" class="text-xs text-red-600 mt-1">
+                <p>Username is required!</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex flex-col mb-4">
+            <input-field
+              name="password"
+              [label]="'New Password'"
+              class="col-span-2"
+              [className]="'w-full col-span-2'"
+              [type]="InputType.password"
+              [(value)]="password"
+              [form]="form"
+            ></input-field>
+            <div class="h-5">
+              <div class="text-xs text-red-600 mt-1 h-3">
+                <p *ngIf="submitted && !password">Password is required!</p>
+                <p *ngIf="submitted && password && password.length < 8">
+                  Password must be at least 8 characters!
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex flex-col mb-6">
+            <input-field
+              name="confirmPassword"
+              [label]="'Confirm Password'"
+              class="col-span-2"
+              [className]="'w-full col-span-2'"
+              [type]="InputType.password"
+              [(value)]="confirmPassword"
+              [form]="form"
+            ></input-field>
+            <div class="h-5">
+              <div class="text-xs text-red-600 mt-1 h-3">
+                <p *ngIf="submitted && !confirmPassword">Please confirm your password!</p>
+                <p *ngIf="submitted && confirmPassword && password !== confirmPassword">
+                  Passwords do not match!
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div *ngIf="errorMessage" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+            <p class="text-sm">{{ errorMessage }}</p>
+          </div>
+
+          <simple-button className="w-full py-3 mt-2 font-semibold text-white rounded-lg" (click)="resetPassword()">
+            Reset Password
+          </simple-button>
+
+          <div class="flex justify-center mt-3">
+            <a class="text-sm text-primary underline hover:text-primary-light" [routerLink]="['/forgot-password']">
+              Request a new reset link
+            </a>
+          </div>
+        </form>
+      </div>
+
+      <div *ngIf="error && errorMessage" class="text-center">
+        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+          <p class="font-bold">Password Reset Failed</p>
+          <p class="text-sm mt-2">{{ errorMessage }}</p>
+        </div>
+
+        <simple-button className="w-full py-3 mt-4 font-semibold text-white rounded-lg" [routerLink]="['/forgot-password']">
+          Request New Reset Link
+        </simple-button>
+
+        <div class="flex justify-center mt-3">
+          <a class="text-sm text-primary underline hover:text-primary-light" [routerLink]="['/login']">
+            Return to Login
+          </a>
+        </div>
+      </div>
+
+      <div *ngIf="success" class="text-center">
+        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+          <p class="font-bold">Password Reset Successful!</p>
+          <p class="text-sm mt-2">
+            Your password has been successfully reset. You can now log in with your new password.
+          </p>
+        </div>
+
+        <simple-button className="w-full py-3 mt-4 font-semibold text-white rounded-lg" [routerLink]="['/login']">
+          Go to Login
+        </simple-button>
+      </div>
+    </div>
+  </div>
+
+  <loading-spinner [isLoading]="isLoading"></loading-spinner>
+</page-layout>

--- a/frontend/src/app/pages/auth/reset-password/reset-password-page.ts
+++ b/frontend/src/app/pages/auth/reset-password/reset-password-page.ts
@@ -1,0 +1,125 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterModule, ActivatedRoute } from '@angular/router';
+import { AccountsApiService } from '../../../../generated';
+import { PageLayoutComponent } from '../../../components/Layout/PageLayout';
+import { FormsModule } from '@angular/forms';
+import { SimpleButtonComponent } from '../../../components/Button/SimpleButton';
+import { InputFieldComponent, InputType } from '../../../components/Input/InputField';
+import { ErrorService } from '../../../globals/error.service';
+import { LoadingSpinnerComponent } from '../../../components/LoadingSpinner/LoadingSpinner';
+
+@Component({
+    selector: 'app-reset-password',
+    imports: [
+        CommonModule,
+        PageLayoutComponent,
+        FormsModule,
+        SimpleButtonComponent,
+        InputFieldComponent,
+        RouterModule,
+        LoadingSpinnerComponent,
+    ],
+    templateUrl: './reset-password-page.html'
+})
+export class ResetPasswordComponent {
+  InputType = InputType;
+  username: string = '';
+  password: string = '';
+  confirmPassword: string = '';
+  token: string = '';
+
+  // After first submission attempt, form validation will start
+  submitted = false;
+  // Success flag
+  success = false;
+  // Error flag
+  error = false;
+  errorMessage = '';
+
+  isLoading = false;
+
+  constructor(
+    private accountsApiService: AccountsApiService,
+    private router: Router,
+    private route: ActivatedRoute,
+    private errorService: ErrorService
+  ) {}
+
+  ngOnInit() {
+    // Get token from query parameters
+    this.route.queryParams.subscribe(params => {
+      this.token = params['token'] || '';
+      if (!this.token) {
+        this.error = true;
+        this.errorMessage = 'Invalid or missing reset token. Please request a new password reset link.';
+      }
+    });
+  }
+
+  /**
+   * Form validation will start after the method is called, additionally a password reset commit will be sent
+   */
+  resetPassword() {
+    this.submitted = true;
+    this.error = false;
+    this.success = false;
+    this.errorMessage = '';
+
+    // Check if all fields are valid
+    if (!this.username || this.username.trim().length === 0) {
+      this.errorMessage = 'Username is required';
+      this.error = true;
+      return;
+    }
+
+    if (!this.password || this.password.length < 8) {
+      this.errorMessage = 'Password must be at least 8 characters';
+      this.error = true;
+      return;
+    }
+
+    if (this.password !== this.confirmPassword) {
+      this.errorMessage = 'Passwords do not match';
+      this.error = true;
+      return;
+    }
+
+    if (!this.token) {
+      this.errorMessage = 'Invalid reset token';
+      this.error = true;
+      return;
+    }
+
+    this.commitPasswordReset(this.username, this.token, this.password);
+  }
+
+  /**
+   * Send password reset commit request to the backend.
+   *
+   * @param username username
+   * @param token reset token from email
+   * @param password new password
+   */
+  commitPasswordReset(username: string, token: string, password: string) {
+    this.isLoading = true;
+    this.accountsApiService.resetPasswordCommit(username, token, { password }).subscribe({
+      next: () => {
+        this.isLoading = false;
+        this.success = true;
+        this.error = false;
+      },
+      error: (error) => {
+        this.isLoading = false;
+        this.error = true;
+        if (typeof error.error === 'object') {
+          this.errorMessage = error.error.message || 'Password reset failed. The link may have expired or is invalid.';
+          this.errorService.printErrorResponse(error);
+        } else {
+          this.errorMessage = error.error || 'Password reset failed. The link may have expired or is invalid.';
+          this.errorService.printErrorResponse(error);
+        }
+      },
+    });
+  }
+}


### PR DESCRIPTION
Implemented the missing frontend components for the password-reset functionality that already exists in the backend:

- Created forgot-password page (/forgot-password) where users can request a password reset by entering their username
- Created reset-password page (/reset-password) where users can set a new password using the token from their email
- Added routes for both new pages in app.routes.ts
- Added "Forgot Password?" link to the login page
- Both components use the existing AccountsApiService methods (resetPasswordInitiate and resetPasswordCommit)
- Includes proper form validation and user-friendly error/success messages
- Follows existing UI/UX patterns from the codebase

Backend already has comprehensive integration tests covering all password-reset scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)